### PR TITLE
fix: thread spawn sets first arg as package name

### DIFF
--- a/crates/hayride-runtime/src/silo/silo_impl.rs
+++ b/crates/hayride-runtime/src/silo/silo_impl.rs
@@ -141,7 +141,7 @@ where
         &mut self,
         morph: String,
         function: String,
-        args: Vec<String>,
+        mut args: Vec<String>,
     ) -> Result<Resource<Thread>, threads::ErrNo> {
         log::debug!(
             "executing spawn: {} with function: {}, and args: {:?}",
@@ -149,6 +149,9 @@ where
             function,
             args
         );
+
+        // add the morph as the first argument
+        args.insert(0, morph.clone());
 
         let mut path = dirs::home_dir().ok_or_else(|| ErrNo::MissingHomedir)?;
         path.push(self.ctx().registry_path.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,12 +70,7 @@ async fn main() -> Result<()> {
     .build()?;
 
     // Parse args to pass to the component
-    let mut args: Vec<String> = env::args().collect();
-
-    // If no args are provided at least set empty for the option arg
-    if args.len() < 1 {
-        args.push("".to_string());
-    }
+    let args: Vec<String> = env::args().collect();
 
     let mut morph_path = home_dir;
     morph_path.push(morphs_dir);


### PR DESCRIPTION
# Description

- Thread spawn will now prepend the package name as the binary/program first arg for wasmtime instances to match the Rust os Args convention
- Removed unused args push in main 