### PR TITLE
feat: add host imports for ai context and tools as fallback

### DIFF
--- a/crates/hayride-host-traits/src/ai.rs
+++ b/crates/hayride-host-traits/src/ai.rs
@@ -1,6 +1,8 @@
 pub mod model;
 pub mod nn;
 pub mod rag;
+pub mod context;
+pub mod tools;
 
 pub use nn::{
     BackendError, BackendExecutionContext, BackendGraph, BackendInner, Error, ErrorCode,

--- a/crates/hayride-host-traits/src/ai/context.rs
+++ b/crates/hayride-host-traits/src/ai/context.rs
@@ -1,0 +1,5 @@
+pub mod errors;
+pub mod context;
+
+pub use errors::{Error, ErrorCode};
+pub use context::Context;

--- a/crates/hayride-host-traits/src/ai/context/context.rs
+++ b/crates/hayride-host-traits/src/ai/context/context.rs
@@ -1,0 +1,5 @@
+// backend defined Context to represent the resource, but not currently used
+// This is a fallback for when a component does not implement the Context import.
+pub struct Context {
+    
+}   

--- a/crates/hayride-host-traits/src/ai/context/errors.rs
+++ b/crates/hayride-host-traits/src/ai/context/errors.rs
@@ -1,0 +1,29 @@
+use std::fmt;
+
+/// Host side model-loader error.
+#[derive(Debug)]
+pub struct Error {
+    pub code: ErrorCode,
+    pub data: anyhow::Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorCode {
+    UnexpectedMessageType,
+    PushError,
+    MessageNotFound,
+    Unknown,
+}
+
+// Implement Display for ErrorCode
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let description = match self {
+            ErrorCode::UnexpectedMessageType => "Unexpected message type",
+            ErrorCode::PushError => "Error pushing message",
+            ErrorCode::MessageNotFound => "Message not found",
+            ErrorCode::Unknown => "Unknown",
+        };
+        write!(f, "{}", description)
+    }
+}

--- a/crates/hayride-host-traits/src/ai/tools.rs
+++ b/crates/hayride-host-traits/src/ai/tools.rs
@@ -1,0 +1,5 @@
+pub mod errors;
+pub mod tools;
+
+pub use errors::{Error, ErrorCode};
+pub use tools::Tools;

--- a/crates/hayride-host-traits/src/ai/tools/errors.rs
+++ b/crates/hayride-host-traits/src/ai/tools/errors.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+/// Host side model-loader error.
+#[derive(Debug)]
+pub struct Error {
+    pub code: ErrorCode,
+    pub data: anyhow::Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorCode {
+    ToolCallFailed,
+    ToolNotFound,
+    Unknown,
+}
+
+// Implement Display for ErrorCode
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let description = match self {
+            ErrorCode::ToolCallFailed => "Tool call failed",
+            ErrorCode::ToolNotFound => "Tool not found",
+            ErrorCode::Unknown => "Unknown",
+        };
+        write!(f, "{}", description)
+    }
+}

--- a/crates/hayride-host-traits/src/ai/tools/tools.rs
+++ b/crates/hayride-host-traits/src/ai/tools/tools.rs
@@ -1,0 +1,5 @@
+// backend defined Tools to represent the resource, but not currently used
+// This is a fallback for when a component does not implement the Tools import.
+pub struct Tools {
+    
+}   

--- a/crates/hayride-runtime/src/ai.rs
+++ b/crates/hayride-runtime/src/ai.rs
@@ -22,12 +22,16 @@ where
     bindings::graph::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
     bindings::inference::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
     bindings::errors::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
-    bindings::tensor_stream::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
-    bindings::graph_stream::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
-    bindings::inference_stream::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
-    bindings::rag::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
-    bindings::transformer::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
-    bindings::model_repository::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::ai::tensor_stream::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::ai::graph_stream::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::ai::inference_stream::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::ai::rag::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::ai::transformer::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::ai::model_repository::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+
+    // Context and Tools bindings are added as a fallback to satisfy the imports if they are needed.
+    bindings::ai::context::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
+    bindings::mcp::tools::add_to_linker::<T, HasAi<T>>(l, |x| AiImpl(x))?;
 
     Ok(())
 }

--- a/crates/hayride-runtime/src/ai/bindings.rs
+++ b/crates/hayride-runtime/src/ai/bindings.rs
@@ -26,11 +26,15 @@ mod generated {
             "hayride:ai/transformer/transformer": hayride_host_traits::ai::rag::Transformer,
             "hayride:ai/rag/error": hayride_host_traits::ai::rag::Error,
             "hayride:ai/model-repository/error": hayride_host_traits::ai::model::Error,
+            "hayride:ai/context/context": hayride_host_traits::ai::context::Context,
+            "hayride:ai/context/error": hayride_host_traits::ai::context::Error,
+            "hayride:mcp/tools/tools": hayride_host_traits::ai::tools::Tools,
+            "hayride:mcp/tools/error": hayride_host_traits::ai::tools::Error,
         },
     });
 }
 
-pub use self::generated::hayride::ai::*;
+pub use self::generated::hayride::*;
 pub use self::generated::wasi::nn::*;
 
 // Convert from generated types to hayride_host_traits types

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -26,6 +26,10 @@ world hayride-ai {
 
     import hayride:ai/model-repository@0.0.61;
     import hayride:ai/rag@0.0.61;
+
+    // Host satisfies context and tools as a fallback.
+    import hayride:ai/context@0.0.61;
+    import hayride:mcp/tools@0.0.61;
 }
 
 world hayride-core {


### PR DESCRIPTION
# Description

Added bindings to ai interface for context and tools with error resources implemented and resources themselves mocked.
If a component has these imports and they get linked by the host runtime we will return errors on the resource functions indicating that they are not implemented.