### PR TITLE
feat: update to wasmtime v36, fix imports, replace file_stdin with InputFile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ toml = "0.9.5"
 url = "2.5.7"
 uuid = { version = "1.18.1", features = ["v4"] }
 windows-sys = "0.60.2"
-wasmtime = "34.0.0"
-wasmtime-wasi = "34.0.0"
-wasmtime-wasi-http = "34.0.0"
+wasmtime = "36.0.2"
+wasmtime-wasi = "36.0.2"
+wasmtime-wasi-http = "36.0.2"
 wit-parser = "0.225.0"
 
 # hf deps

--- a/crates/hayride-runtime/src/ai.rs
+++ b/crates/hayride-runtime/src/ai.rs
@@ -6,8 +6,6 @@ pub mod bindings;
 pub use ai::AiCtx;
 pub use ai::{AiImpl, AiView};
 
-pub use bindings::inference::GraphExecutionContext;
-
 use hayride_host_traits::ai::model::ModelRepositoryInner;
 use hayride_host_traits::ai::rag::RagInner;
 use hayride_host_traits::ai::BackendInner;

--- a/crates/hayride-runtime/src/ai/bindings.rs
+++ b/crates/hayride-runtime/src/ai/bindings.rs
@@ -10,7 +10,9 @@ mod generated {
         require_store_data_send: true,
 
         // Wrap functions returns with a result with error
-        trappable_imports: true,
+        imports: {
+            default: trappable,
+        },
         with: {
             // Upstream package dependencies
             "wasi:io": wasmtime_wasi::p2::bindings::io,

--- a/crates/hayride-runtime/src/bindings.rs
+++ b/crates/hayride-runtime/src/bindings.rs
@@ -9,7 +9,9 @@ pub mod hayride_cli {
         // This is helpful when sync bindings depend on generated functions from
         // async bindings as is the case with WASI in-tree.
         require_store_data_send: true,
-        async: true,
+        exports: {
+            default: async,
+        },
     });
 }
 
@@ -24,7 +26,9 @@ pub mod hayride_server {
         // This is helpful when sync bindings depend on generated functions from
         // async bindings as is the case with WASI in-tree.
         require_store_data_send: true,
-        async: true,
+        exports: {
+            default: async,
+        },
         with: {
             // Upstream package dependencies
             "wasi:io": wasmtime_wasi::p2::bindings::io,
@@ -55,7 +59,9 @@ pub mod hayride_ws {
         // This is helpful when sync bindings depend on generated functions from
         // async bindings as is the case with WASI in-tree.
         require_store_data_send: true,
-        async: true,
+        exports: {
+            default: async,
+        },
         with: {
             // Upstream package dependencies
             "wasi:io": wasmtime_wasi::p2::bindings::io,

--- a/crates/hayride-runtime/src/core/bindings.rs
+++ b/crates/hayride-runtime/src/core/bindings.rs
@@ -2,7 +2,9 @@ pub mod generated {
     wasmtime::component::bindgen!({
         path: "../../wit",
         world: "hayride-core",
-        trappable_imports: true,
+        imports: {
+            default: trappable,
+        },
         with: {
             "hayride:core/version/error": hayride_host_traits::core::version::Error,
         },

--- a/crates/hayride-runtime/src/db/bindings.rs
+++ b/crates/hayride-runtime/src/db/bindings.rs
@@ -2,7 +2,9 @@ pub mod generated {
     wasmtime::component::bindgen!({
         path: "../../wit",
         world: "hayride-db",
-        trappable_imports: true,
+        imports: {
+            default: trappable,
+        },
         with: {
             "hayride:db/db/error": hayride_host_traits::db::Error,
             "hayride:db/db/connection": hayride_host_traits::db::Connection,

--- a/crates/hayride-runtime/src/lib.rs
+++ b/crates/hayride-runtime/src/lib.rs
@@ -16,18 +16,11 @@ use crate::mcp::{McpCtx, McpView};
 use crate::silo::{SiloCtx, SiloView};
 use crate::wac::{WacCtx, WacView};
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use std::io::{Read, Seek, SeekFrom};
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::Mutex;
 use uuid::Uuid;
 use wasmtime::component::ResourceTable;
-use wasmtime_wasi::p2::{
-    InputStream, IoView, OutputFile, StdinStream, StreamError, StreamResult, WasiCtx,
-    WasiCtxBuilder, WasiView,
-};
+use wasmtime_wasi::cli::{InputFile, OutputFile};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 
 pub struct Host {
@@ -43,8 +36,11 @@ pub struct Host {
 }
 
 impl WasiView for Host {
-    fn ctx(&mut self) -> &mut WasiCtx {
-        &mut self.ctx
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.ctx,
+            table: &mut self.table,
+        }
     }
 }
 
@@ -52,9 +48,7 @@ impl WasiHttpView for Host {
     fn ctx(&mut self) -> &mut WasiHttpCtx {
         &mut self.http_ctx
     }
-}
 
-impl IoView for Host {
     fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
     }
@@ -193,7 +187,8 @@ fn create_wasi_ctx(
                 .open(input_path.clone())
                 .expect("Failed to open input file");
 
-            let file_stdin = FileStdin::new(std::path::PathBuf::from(&input_path));
+            let file = std::fs::File::open(&input_path)?;
+            let file_stdin = InputFile::new(file);
 
             wasi_ctx_builder = wasi_ctx_builder.stdin(file_stdin);
         }
@@ -202,130 +197,4 @@ fn create_wasi_ctx(
     let wasi_ctx: WasiCtx = wasi_ctx_builder.build();
 
     Ok(wasi_ctx)
-}
-
-/// Represents the StdinStream (a factory for producing input streams)
-struct FileStdin {
-    path: PathBuf, // Path to reopen file if needed
-}
-
-impl FileStdin {
-    pub fn new(path: PathBuf) -> Self {
-        Self { path }
-    }
-}
-
-impl StdinStream for FileStdin {
-    fn stream(&self) -> Box<dyn InputStream> {
-        Box::new(FileHostInputStream {
-            path: self.path.clone(),
-            position: Arc::new(Mutex::new(0)), // Track position across reads
-        })
-    }
-
-    fn isatty(&self) -> bool {
-        false
-    }
-}
-
-/// Our real file-based input stream
-pub struct FileHostInputStream {
-    path: PathBuf,
-    position: Arc<Mutex<u64>>, // Track position across reads
-}
-
-#[async_trait]
-impl wasmtime_wasi::p2::Pollable for FileHostInputStream {
-    async fn ready(&mut self) {
-        let path = self.path.clone();
-        let pos = self.position.clone();
-
-        loop {
-            // Try to get metadata
-            match std::fs::metadata(&path) {
-                Ok(metadata) => {
-                    let file_size = metadata.len();
-
-                    // Try to lock position
-                    if let Ok(position) = pos.lock() {
-                        if *position < file_size {
-                            // There is new data available
-                            return;
-                        }
-                    } else {
-                        // Couldn't lock position; treat as not ready
-                    }
-                }
-                Err(_) => {
-                    // Could not get metadata; treat as not ready yet
-                }
-            }
-
-            // No data available yet, wait a bit
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-    }
-}
-
-#[async_trait]
-impl InputStream for FileHostInputStream {
-    fn read(&mut self, size: usize) -> StreamResult<Bytes> {
-        let pos = self.position.clone();
-        let path = self.path.clone();
-
-        let mut position = pos.lock().map_err(|_| StreamError::Closed)?;
-        let metadata = std::fs::metadata(&path).map_err(|_| StreamError::Closed)?;
-        let file_size = metadata.len();
-
-        if *position >= file_size {
-            return Ok(Bytes::new());
-        }
-
-        // Reopen the file to read from it
-        let mut file = std::fs::File::open(&path).map_err(|_| StreamError::Closed)?;
-
-        file.seek(SeekFrom::Start(*position))
-            .map_err(|_| StreamError::Closed)?;
-
-        let bytes_available = (file_size - *position) as usize;
-        let to_read = std::cmp::min(size, bytes_available);
-
-        let mut buf = vec![0; to_read];
-        let n = file.read(&mut buf).map_err(|_| StreamError::Closed)?;
-
-        if n == 0 {
-            return Ok(Bytes::new());
-        }
-
-        *position += n as u64;
-
-        Ok(Bytes::copy_from_slice(&buf[..n]))
-    }
-
-    async fn blocking_read(&mut self, size: usize) -> StreamResult<Bytes> {
-        loop {
-            let bytes = self.read(size)?;
-
-            if bytes.is_empty() {
-                // No data yet, wait a little and retry
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                continue;
-            }
-
-            return Ok(bytes);
-        }
-    }
-
-    fn skip(&mut self, nelem: usize) -> StreamResult<usize> {
-        self.read(nelem).map(|bytes| bytes.len())
-    }
-
-    async fn blocking_skip(&mut self, nelem: usize) -> StreamResult<usize> {
-        let bytes = self.blocking_read(nelem).await?;
-        Ok(bytes.len())
-    }
-
-    async fn cancel(&mut self) {
-        // No-op for now: nothing async that needs to be cancelled
-    }
 }

--- a/crates/hayride-runtime/src/mcp/bindings.rs
+++ b/crates/hayride-runtime/src/mcp/bindings.rs
@@ -10,7 +10,9 @@ mod generated {
         require_store_data_send: true,
 
         // Wrap functions returns with a result with error
-        trappable_imports: true,
+        imports: {
+            default: trappable,
+        },
         with: {
             "hayride:mcp/tools/tools": hayride_host_traits::mcp::tools::Tools,
             "hayride:mcp/tools/error": hayride_host_traits::mcp::tools::Error,

--- a/crates/hayride-runtime/src/wac/bindings.rs
+++ b/crates/hayride-runtime/src/wac/bindings.rs
@@ -2,7 +2,9 @@ pub mod generated {
     wasmtime::component::bindgen!({
         path: "../../wit",
         world: "hayride-wac",
-        trappable_imports: true,
+        imports: {
+            default: trappable,
+        },
         with: {
             "hayride:wac/wac/error": hayride_host_traits::wac::Error,
         },


### PR DESCRIPTION
# Description

- Updated Wasmtime deps to v36.0.2
- Updating bindings config and import paths for wasi
- Replaced custom FileStdin with `wasmtime_wasi::cli::InputFile`
- Implemented AsyncWrite for WebsocketOutputPipe to satisfy `StdoutStream`